### PR TITLE
Modify shellscript for MacOS

### DIFF
--- a/broker/ruby_broker/grpc_test.sh
+++ b/broker/ruby_broker/grpc_test.sh
@@ -15,8 +15,8 @@ bundle exec ruby send_client.rb $1 $2
 
 while(true)
 do
-    if [ "$(ps -p $RECVID |wc -l)" = "1" ]; then
-	break
+    if [ $(ps -p $RECVID | wc -l) = "1" ]; then
+    break
     fi
     sleep 1
 done


### PR DESCRIPTION
MacOSでは，wc が出力する文字列の先頭にスペースを含み，文字列比較が常にfalseになるため，これを修正した．